### PR TITLE
Fix thousands splits when local is not 'en' compatible

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,7 @@ class FrenchNumbersToWords {
     this.result.parts = [];
     // we will split the number to groups
     // each group has three digits. Ex: 12345 will have two groups: 12 (for thousands) and 345
-    this.numberParts = this.number.toLocaleString().split(",").map(Number);
+    this.numberParts = this.number.toLocaleString('en').split(",").map(Number);
     let n: number, full: ResultPart;
     for (let j = 0; j < this.numberParts.length; j++) {
       n = this.numberParts[j];


### PR DESCRIPTION
When local environment is not 'en' compatible, the number is written like that `123 456` instead of `123,456`, so the "thousands split" doesn't work.

This PR fix it by forcing the toLocaleString() method to use "en" local.